### PR TITLE
Tutorial show bug

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,10 +1,11 @@
 class TutorialsController < ApplicationController
   def show
     tutorial = Tutorial.find(params[:id])
-    if tutorial.classroom == false || current_user
-      @facade = TutorialFacade.new(tutorial, params[:video_id])
-    else
+    if tutorial.videos.empty?
+      flash[:error] = "That tutorial does not currently have videos"
       redirect_to root_path
     end
+    redirect_to root_path unless tutorial.classroom == false || current_user
+    @facade = TutorialFacade.new(tutorial, params[:video_id])
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -2,4 +2,9 @@ class Video < ApplicationRecord
   has_many :bookmarks
   has_many :users, through: :bookmarks
   belongs_to :tutorial
+
+  validates :position, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 0
+  }
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_30_233928) do
+ActiveRecord::Schema.define(version: 2019_02_02_231049) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/features/user/user_can_see_tutorials_on_root_spec.rb
+++ b/spec/features/user/user_can_see_tutorials_on_root_spec.rb
@@ -4,6 +4,7 @@ describe 'user sees all tutorials' do
   before(:each) do
     @tutorial_1 = create(:tutorial, classroom: false)
     @tutorial_2 = create(:tutorial, classroom: true)
+    @tutorial_3 = create(:tutorial, classroom: false)
     @video_1 = create(:video, tutorial_id: @tutorial_1.id)
     @video_2 = create(:video, tutorial_id: @tutorial_2.id)
 
@@ -28,5 +29,11 @@ describe 'user sees all tutorials' do
     click_on @tutorial_1.title
 
     expect(current_path).to eq(tutorial_path(@tutorial_1))
+  end
+  it 'user does not see tutorial show if tutorial has no videos' do
+    visit tutorial_path(@tutorial_3)
+
+    expect(current_path).to eq(root_path)
+    expect(page).to have_content("That tutorial does not currently have videos")
   end
 end

--- a/spec/features/user/user_sees_bookmarks_spec.rb
+++ b/spec/features/user/user_sees_bookmarks_spec.rb
@@ -50,17 +50,17 @@ describe 'Rendering Bookmarked Segments' do
     it 'links to tutorial path for video through video name' do
       expect(page).to have_link("#{@video.title}", href: "/tutorials/#{@tutorial.id}?video_id=#{@video.id}")
       click_link "#{@video.title}"
-      expect(current_url).to eq("http://www.example.com#{tutorial_path(@tutorial.id, video_id: @video.id)}")
+      expect(current_url).to eq("http://localhost:3000#{tutorial_path(@tutorial.id, video_id: @video.id)}")
 
       visit dashboard_path
       expect(page).to have_link("#{@video_2.title}", href: "/tutorials/#{@tutorial_2.id}?video_id=#{@video_2.id}")
       click_link "#{@video_2.title}"
-      expect(current_url).to eq("http://www.example.com#{tutorial_path(@tutorial_2.id, video_id: @video_2.id)}")
+      expect(current_url).to eq("http://localhost:3000#{tutorial_path(@tutorial_2.id, video_id: @video_2.id)}")
 
       visit dashboard_path
       expect(page).to have_link("#{@video_3.title}", href: "/tutorials/#{@tutorial_2.id}?video_id=#{@video_3.id}")
       click_link "#{@video_3.title}"
-      expect(current_url).to eq("http://www.example.com#{tutorial_path(@tutorial_2.id, video_id: @video_3.id)}")
+      expect(current_url).to eq("http://localhost:3000#{tutorial_path(@tutorial_2.id, video_id: @video_3.id)}")
     end
   end
 end

--- a/spec/features/vistors/visitor_sees_a_video_show_spec.rb
+++ b/spec/features/vistors/visitor_sees_a_video_show_spec.rb
@@ -4,7 +4,6 @@ describe 'visitor sees a video show' do
   it 'vistor clicks on a tutorial title from the home page' do
     tutorial = create(:tutorial)
     video = create(:video, tutorial_id: tutorial.id)
-
     visit '/'
 
     click_on tutorial.title
@@ -38,5 +37,13 @@ describe 'visitor sees a video show' do
     visit tutorial_path(tutorial)
 
     expect(current_path).to eq(root_path)
+  end
+  it 'visitor does not see tutorial show if tutorial has no videos' do
+    tutorial = create(:tutorial, classroom: false)
+
+    visit tutorial_path(tutorial)
+
+    expect(current_path).to eq(root_path)
+    expect(page).to have_content("That tutorial does not currently have videos")
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe Video, type: :model do
+  describe 'validations' do
+    it {should validate_numericality_of(:position).only_integer}
+    it {should validate_numericality_of(:position).is_greater_than_or_equal_to(0)}
+  end
+  describe 'relationships' do
+    it {should have_many(:bookmarks)}
+    it {should have_many(:users).through(:bookmarks)}
+    it {should belong_to(:tutorial)}
+  end
+end


### PR DESCRIPTION
## Tutorial show page won't load if missing videos #8
## Add validation on `position` to `Video` model #9

Fixes both bugs
* In `TutorialsController#show` - if found tutorial `.videos` is empty then redirect with flash message
* No creating records for #9 because that isn't neccesary - `videos` table has a default value and numericality and being greater than 0 for position are validations on `Video`. Shoulda matchers takes care of that.